### PR TITLE
Make Bon Voyage Autopilot part physicsless

### DIFF
--- a/GameData/BonVoyage/Parts/part.cfg
+++ b/GameData/BonVoyage/Parts/part.cfg
@@ -24,6 +24,7 @@ PART
     angularDrag = 1
     crashTolerance = 8
     maxTemp = 3200
+    PhysicsSignificance = 1
 
     MODULE
     {


### PR DESCRIPTION
The Bon Voyage Autopilot part is very cool with its animation -- but I was surprised to note that it wasn't coded to be "physicsless" akin to the stock science experiment parts such as the thermometer, despite the fact that it is essentially massless at a mere 1 kg.

I've added PhysicsSignificance = 1 to the autopilot part, which brings it in line with the stock low-mass parts, and should ever-so-slightly improve performance.